### PR TITLE
Reset password when password_wo_version changed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,5 +86,5 @@ jobs:
           TF_ACC: "1"
           TF_VAR_raito_user: ${{ secrets.RAITO_USER }}
           TF_VAR_raito_secret: ${{ secrets.RAITO_SECRET }}
-        run: go test -v -cover ./internal/
+        run: go test -v -cover ./internal/ -timeout 0
         timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,16 @@ jobs:
       - build
       - generate
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.6.*'
-          - '1.7.*'
-          - '1.8.*'
-          - '1.9.*'
           - '1.10.*'
           - '1.11.*'
+          - '1.12.*'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -90,4 +87,4 @@ jobs:
           TF_VAR_raito_user: ${{ secrets.RAITO_USER }}
           TF_VAR_raito_secret: ${{ secrets.RAITO_SECRET }}
         run: go test -v -cover ./internal/
-        timeout-minutes: 10
+        timeout-minutes: 15

--- a/internal/user_resource.go
+++ b/internal/user_resource.go
@@ -282,12 +282,13 @@ func (u *UserResource) Read(ctx context.Context, request resource.ReadRequest, r
 	}
 
 	actualData := UserResourceModel{
-		Id:        types.StringValue(user.Id),
-		Name:      types.StringValue(user.Name),
-		Email:     types.StringPointerValue(user.Email),
-		Type:      types.StringValue(string(user.Type)),
-		Password:  stateData.Password,
-		RaitoUser: types.BoolValue(user.IsRaitoUser),
+		Id:                types.StringValue(user.Id),
+		Name:              types.StringValue(user.Name),
+		Email:             types.StringPointerValue(user.Email),
+		Type:              types.StringValue(string(user.Type)),
+		Password:          stateData.Password,
+		PasswordWoVersion: stateData.PasswordWoVersion,
+		RaitoUser:         types.BoolValue(user.IsRaitoUser),
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &actualData)...)

--- a/internal/user_resource.go
+++ b/internal/user_resource.go
@@ -154,7 +154,7 @@ func (u *UserResource) Schema(ctx context.Context, request resource.SchemaReques
 				Description:         "Version of the password_wo. This is used to force the password to be updated.",
 				MarkdownDescription: "Version of the password_wo. This is used to force the password to be updated.",
 				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.RequiresReplace(),
+					int32planmodifier.UseStateForUnknown(),
 				},
 				Default: nil,
 			},

--- a/internal/user_resource.go
+++ b/internal/user_resource.go
@@ -341,6 +341,13 @@ func (u *UserResource) Update(ctx context.Context, request resource.UpdateReques
 
 			return
 		}
+	} else if !planData.PasswordWo.IsNull() && !planData.PasswordWoVersion.IsNull() && !stateData.PasswordWoVersion.Equal(planData.PasswordWoVersion) {
+		user, err = u.client.User().SetUserPassword(ctx, user.Id, planData.PasswordWo.ValueString())
+		if err != nil {
+			response.Diagnostics.AddError("Failed to set user password_wo", err.Error())
+
+			return
+		}
 	}
 
 	planData.RaitoUser = types.BoolValue(user.IsRaitoUser)

--- a/internal/user_resource_test.go
+++ b/internal/user_resource_test.go
@@ -101,6 +101,102 @@ resource "raito_user" "u1" {
 		})
 	})
 
+	t.Run("user with password write only", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			IsUnitTest: false,
+			PreCheck: func() {
+				AccProviderPreCheck(t)
+			},
+			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+				tfversion.SkipBelow(tfversion.Version1_0_0),
+			},
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: providerConfig + fmt.Sprintf(`
+resource "raito_user" "u1" {
+	name = "tfTestUser-%[1]s"
+	email = "test-user-%[1]s@raito.io"
+	raito_user = true
+}
+`, testId),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("raito_user.u1", "name", fmt.Sprintf("tfTestUser-%s", testId)),
+						resource.TestCheckResourceAttr("raito_user.u1", "email", fmt.Sprintf("test-user-%s@raito.io", testId)),
+						resource.TestCheckResourceAttr("raito_user.u1", "raito_user", "true"),
+						resource.TestCheckResourceAttr("raito_user.u1", "type", "Human"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password_wo"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password_wo_version"),
+						resource.TestCheckResourceAttrWith("raito_user.u1", "id", func(value string) error {
+							if len(value) == 0 {
+								return fmt.Errorf("ID should not be empty")
+							}
+
+							return nil
+						}),
+					),
+				},
+				{
+					Config: providerConfig + fmt.Sprintf(`
+resource "raito_user" "u1" {
+	name = "tfTestUser-%[1]s"
+	email = "test-user-%[1]s@raito.io"
+	raito_user = true
+	type = "Machine"
+	password_wo = "!23vV678"
+	password_wo_version = 1
+}
+`, testId),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("raito_user.u1", "name", fmt.Sprintf("tfTestUser-%s", testId)),
+						resource.TestCheckResourceAttr("raito_user.u1", "email", fmt.Sprintf("test-user-%s@raito.io", testId)),
+						resource.TestCheckResourceAttr("raito_user.u1", "raito_user", "true"),
+						resource.TestCheckResourceAttr("raito_user.u1", "type", "Machine"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password_wo"),
+						resource.TestCheckResourceAttr("raito_user.u1", "password_wo_version", "1"),
+						resource.TestCheckResourceAttrWith("raito_user.u1", "id", func(value string) error {
+							if len(value) == 0 {
+								return fmt.Errorf("ID should not be empty")
+							}
+
+							return nil
+						}),
+					),
+				},
+				{
+					Config: providerConfig + fmt.Sprintf(`
+resource "raito_user" "u1" {
+	name = "tfTestUser-%[1]s"
+	email = "test-user-%[1]s@raito.io"
+	raito_user = true
+	type = "Machine"
+	password_wo = "!23vV679"
+	password_wo_version = 2
+}
+`, testId),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("raito_user.u1", "name", fmt.Sprintf("tfTestUser-%s", testId)),
+						resource.TestCheckResourceAttr("raito_user.u1", "email", fmt.Sprintf("test-user-%s@raito.io", testId)),
+						resource.TestCheckResourceAttr("raito_user.u1", "raito_user", "true"),
+						resource.TestCheckResourceAttr("raito_user.u1", "type", "Machine"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password"),
+						resource.TestCheckNoResourceAttr("raito_user.u1", "password_wo"),
+						resource.TestCheckResourceAttr("raito_user.u1", "password_wo_version", "2"),
+						resource.TestCheckResourceAttrWith("raito_user.u1", "id", func(value string) error {
+							if len(value) == 0 {
+								return fmt.Errorf("ID should not be empty")
+							}
+
+							return nil
+						}),
+					),
+				},
+			},
+		})
+	})
+
 	t.Run("start with raito user", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			IsUnitTest: false,

--- a/internal/user_resource_test.go
+++ b/internal/user_resource_test.go
@@ -108,7 +108,7 @@ resource "raito_user" "u1" {
 				AccProviderPreCheck(t)
 			},
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-				tfversion.SkipBelow(tfversion.Version1_0_0),
+				tfversion.SkipBelow(tfversion.Version1_11_0),
 			},
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			Steps: []resource.TestStep{


### PR DESCRIPTION
This pull request adds support for updating a user's write-only password (`password_wo`) and its version (`password_wo_version`) in the user resource, along with comprehensive tests to verify this new behavior. The main changes are focused on enabling and testing the update logic for write-only passwords for machine-type users.

### User resource update logic

* Added logic to update the user's write-only password (`password_wo`) only when both the new password and its version are provided and the version has changed, ensuring correct password update semantics.

### Testing enhancements

* Introduced a new test case for users with write-only passwords in `internal/user_resource_test.go`, covering creation and update scenarios for machine-type users with `password_wo` and `password_wo_version` attributes.
* The tests verify that the password fields behave as expected (not returned in state) and that the versioning logic works correctly during updates.